### PR TITLE
Update URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,4 +211,4 @@ A postal address:
                rstr.digits(5),
                )
 
-.. _SystemRandom: https://docs.python.org/2/library/random.html#random.SystemRandom
+.. _SystemRandom: https://docs.python.org/3/library/random.html#random.SystemRandom

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='rstr',
                 'random',
                 'strings',
                 'reverse regular expression'],
-      url='http://bitbucket.org/leapfrogdevelopment/rstr/overview',
+      url='https://github.com/leapfrogonline/rstr',
       packages=['rstr', 'rstr.tests'],
       test_suite='rstr.tests.suite',
       )


### PR DESCRIPTION
This PR update links to python3 documentation and github repository. There are the same links in `pkg-info` file but it seems to be a generated file (?).

I think this PR should be merged before releasing the new version  (https://github.com/leapfrogonline/rstr/issues/5).