### PR TITLE
Exception when matching include and exclude parameters

### DIFF
--- a/rstr/rstr_base.py
+++ b/rstr/rstr_base.py
@@ -132,8 +132,13 @@ class RstrBase(object):
         as 'exclude'.
 
         '''
-        if set(include).intersection(exclude):
-            raise SameCharacterError("include and exclude parameters contain same character(s)")
+        same_characters = set(include).intersection(exclude)
+        if same_characters:
+            message = "include and exclude parameters contain same character{plural} ({characters})".format(
+                plural="s" if len(same_characters) > 1 else "",
+                characters=", ".join(same_characters)
+            )
+            raise SameCharacterError(message)
 
         popul = [char for char in list(alphabet) if char not in list(exclude)]
 

--- a/rstr/rstr_base.py
+++ b/rstr/rstr_base.py
@@ -133,7 +133,7 @@ class RstrBase(object):
 
         '''
         if set(include).intersection(exclude):
-            raise SameCharacterError()
+            raise SameCharacterError("include and exclude parameters contain same character(s)")
 
         popul = [char for char in list(alphabet) if char not in list(exclude)]
 

--- a/rstr/rstr_base.py
+++ b/rstr/rstr_base.py
@@ -132,6 +132,9 @@ class RstrBase(object):
         as 'exclude'.
 
         '''
+        if set(include).intersection(exclude):
+            raise SameCharacterError()
+
         popul = [char for char in list(alphabet) if char not in list(exclude)]
 
         if end_range is None:
@@ -157,3 +160,7 @@ class Rstr(RstrBase, Xeger):
         super(Rstr, self).__init__(_random=_random, **alphabets)
 
 default_instance = Rstr()
+
+
+class SameCharacterError(Exception):
+    pass

--- a/rstr/rstr_base.py
+++ b/rstr/rstr_base.py
@@ -162,5 +162,5 @@ class Rstr(RstrBase, Xeger):
 default_instance = Rstr()
 
 
-class SameCharacterError(Exception):
+class SameCharacterError(ValueError):
     pass

--- a/rstr/tests/test_rstr.py
+++ b/rstr/tests/test_rstr.py
@@ -47,10 +47,11 @@ class TestRstr(unittest.TestCase):
             assert 'C' not in self.rs.rstr('ABC', exclude=['C'])
 
     def test_raise_exception_if_include_and_exclude_parameters_contain_same_character(self):
-        with self.assertRaisesRegex(SameCharacterError, r"include and exclude parameters contain same character\(s\)"):
+        with self.assertRaisesRegex(SameCharacterError, r"include and exclude parameters contain same character \(B\)"):
             self.rs.rstr('A', include='B', exclude='B')
             self.rs.rstr('A', include=['B'], exclude=['B'])
-
+        with self.assertRaisesRegex(SameCharacterError, r"include and exclude parameters contain same characters \(., .\)"):
+            self.rs.rstr('A', include='BC', exclude='BC')
 
 class TestSystemRandom(TestRstr):
     def setUp(self):

--- a/rstr/tests/test_rstr.py
+++ b/rstr/tests/test_rstr.py
@@ -53,6 +53,7 @@ class TestRstr(unittest.TestCase):
         with self.assertRaisesRegex(SameCharacterError, r"include and exclude parameters contain same characters \(., .\)"):
             self.rs.rstr('A', include='BC', exclude='BC')
 
+
 class TestSystemRandom(TestRstr):
     def setUp(self):
         self.rs = Rstr(random.SystemRandom())

--- a/rstr/tests/test_rstr.py
+++ b/rstr/tests/test_rstr.py
@@ -47,7 +47,7 @@ class TestRstr(unittest.TestCase):
             assert 'C' not in self.rs.rstr('ABC', exclude=['C'])
 
     def test_raise_exception_if_include_and_exclude_parameters_contain_same_character(self):
-        with self.assertRaises(SameCharacterError):
+        with self.assertRaisesRegex(SameCharacterError, r"include and exclude parameters contain same character\(s\)"):
             self.rs.rstr('A', include='B', exclude='B')
             self.rs.rstr('A', include=['B'], exclude=['B'])
 

--- a/rstr/tests/test_rstr.py
+++ b/rstr/tests/test_rstr.py
@@ -2,7 +2,7 @@ import re
 import unittest
 import random
 
-from rstr.rstr_base import Rstr
+from rstr.rstr_base import Rstr, SameCharacterError
 
 
 def assert_matches(pattern, value):
@@ -45,6 +45,11 @@ class TestRstr(unittest.TestCase):
     def test_exclude_as_list(self):
         for _ in range(0, 100):
             assert 'C' not in self.rs.rstr('ABC', exclude=['C'])
+
+    def test_raise_exception_if_include_and_exclude_parameters_contain_same_character(self):
+        with self.assertRaises(SameCharacterError):
+            self.rs.rstr('A', include='B', exclude='B')
+            self.rs.rstr('A', include=['B'], exclude=['B'])
 
 
 class TestSystemRandom(TestRstr):


### PR DESCRIPTION
This PR is linked to https://github.com/leapfrogonline/rstr/issues/4.

I run the tests with `tox` on python 3.9 only.

I can add commits to improve the message by including the characters raising the exception if you think it's necessary. 