### PR TITLE
Remove cpython3.5 and add cpython3.9 for tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [tox]
-envlist = pypy3,py35,py36,py37,py38
+envlist = pypy3,py36,py37,py38,py39
 [testenv]
 commands=python -m unittest {posargs}


### PR DESCRIPTION
Cpython 3.5 is [currently end-of-life](https://www.python.org/dev/peps/pep-0478/#id4) so I guess it can be removed. 3.9 was released in 2020.

If you want to keep v.3.5, I can modify the patch to only add 3.9.