### PR TITLE
Updates version to 3.1.0

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,9 +1,11 @@
 # Release Notes
 
-## Unreleased
+## 3.1.0
 
 - Fix a bug where setting end_range but not start_range would fail.
 - Statically type the library, using PEP 484 annotations.
+- Drops test coverage for Python 3.6 (EoL December 2021).
+- Adds test coverage for Python 3.10.
 
 ## 3.0.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = rstr
-version = 3.0.0
+version = 3.1.0
 author = Leapfrog Direct Response LLC
 author_email = oss@leapfrogdevelopment.com
 maintainer = Brendan McCollam
@@ -15,10 +15,10 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development :: Testing
 keywords =
     random string
@@ -34,4 +34,4 @@ universal=1
 [options]
 package_dir =
 packages = rstr
-python_requires = >=3.6
+python_requires = >=3.7


### PR DESCRIPTION
- Fix a bug where setting end_range but not start_range would fail.
- Statically type the library, using PEP 484 annotations.
- Drops test coverage for Python 3.6 (EoL December 2021).
- Adds test coverage for Python 3.10.