### PR TITLE
build: fix PEP 561 compatibility

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include LICENSE.txt
-include py.typed
+include rstr/py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,3 +35,4 @@ universal=1
 package_dir =
 packages = rstr
 python_requires = >=3.7
+include_package_data = True


### PR DESCRIPTION
Move `py.typed` into the `rstr` package so that mypy can pick it up.