### PR TITLE
Remove space from {m,n} repetitions test case.

### DIFF
--- a/tests/test_xeger.py
+++ b/tests/test_xeger.py
@@ -34,7 +34,7 @@ class TestXeger(unittest.TestCase):
         assert re.match(pattern, self.rs.xeger(pattern))
 
     def test_literal_with_range_repeat(self) -> None:
-        pattern = r'A{2, 5}'
+        pattern = r'A{2,5}'
         assert re.match(pattern, self.rs.xeger(pattern))
 
     def test_word(self) -> None:


### PR DESCRIPTION
The test case tests.test_xeger.TestXeger.test_literal_with_range_repeat is testing the regexp patten "A{2, 5}" which is think in intended to match the strings: AA, AAA, AAAA and AAAAA.
But it creates the pattern [(LITERAL, 65), (LITERAL, 123), (LITERAL, 50), (LITERAL, 44), (LITERAL, 32), (LITERAL, 53), (LITERAL, 125)] which will match the string "A{2, 5}" and was probably not what was intended.