### PR TITLE
xeger: avoid deprecated sre_parse module in python-3.11+

### DIFF
--- a/rstr/xeger.py
+++ b/rstr/xeger.py
@@ -1,5 +1,4 @@
 import random
-import sre_parse
 import string
 from itertools import chain
 import typing
@@ -9,6 +8,11 @@ from rstr.rstr_base import RstrBase
 
 if typing.TYPE_CHECKING:
     from rstr.rstr_base import _Random
+
+try:
+    import re._parser as sre_parse  # type: ignore[import]
+except ImportError:  # Python < 3.11
+    import sre_parse  # type: ignore[no-redef]
 
 
 # The * and + characters in a regular expression

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy3,py37,py38,py39,py310,typing
+envlist = pypy3,py37,py38,py39,py310,py311,typing
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
The undocumented sre_parse module got deprecated in Python 3.11 which leads to build/test failures on Linux distributions making use of this version, e.g. Ubuntu 23.04.

See bpo-47152: https://github.com/python/cpython/issues/91308