### PR TITLE
Fix signature of _Random.shuffle() to make pyright happy

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Xiaoqin Zhu
 Stéphane Blondon
 Pascal Corpet
 Mark Mayo
+Aurélien Gâteau

--- a/rstr/rstr_base.py
+++ b/rstr/rstr_base.py
@@ -31,30 +31,15 @@ import itertools
 import string
 from functools import partial
 import typing
-from typing import Any, Callable, Iterable, List, Mapping, MutableSequence, Optional, Sequence, TypeVar
+from typing import Iterable, List, Mapping, Optional, Sequence, TypeVar
 
 
 _T = TypeVar('_T')
 
 
 if typing.TYPE_CHECKING:
+    from random import Random
     from typing import Protocol
-
-    class _Random(Protocol):
-        """Partial interface of the random module needed for the rstr library."""
-
-        def randint(self, a: int, b: int) -> int:
-            ...
-
-        def choice(self, seq: Sequence[_T]) -> _T:
-            ...
-
-        def shuffle(
-            self,
-            x: MutableSequence[Any],
-            random: Optional[Callable[[], float]] = ...,
-        ) -> None:
-            ...
 
 
     class _PartialRstrFunc(Protocol):
@@ -124,7 +109,7 @@ class RstrBase():
 
     '''
 
-    def __init__(self, _random: '_Random', **custom_alphabets: str) -> None:
+    def __init__(self, _random: 'Random', **custom_alphabets: str) -> None:
         super().__init__()
         self._random = _random
         self._alphabets = dict(ALPHABETS)

--- a/rstr/xeger.py
+++ b/rstr/xeger.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, Mapping, Pattern, Sequence, Union
 from rstr.rstr_base import RstrBase
 
 if typing.TYPE_CHECKING:
-    from rstr.rstr_base import _Random
+    from random import Random
 
 try:
     import re._parser as sre_parse  # type: ignore[import]
@@ -30,7 +30,7 @@ class Xeger(RstrBase):
     semi-random string from a regular expression.'''
 
     def __init__(
-        self, _random: '_Random' = typing.cast('_Random', random), **custom_alphabets: str,
+        self, _random: 'Random' = typing.cast('Random', random), **custom_alphabets: str,
     ) -> None:
         super().__init__(_random, **custom_alphabets)
         self._cache: Dict[str, str] = {}


### PR DESCRIPTION
## The problem

This code:

```python
from rstr import Rstr
from random import SystemRandom
Rstr(SystemRandom())
```

Fails to pass pyright tests. `_Random.shuffle()` expects two arguments, one optional, but since Python 3.11 `Random.shuffle()` only takes one argument. This is pyright output:

```
$ python -m pyright t.py                             
/home/agateau/others_src/rstr/t.py
  /home/agateau/others_src/rstr/t.py:3:6 - error: Argument of type "SystemRandom" cannot be assigned to parameter "_random" of type "_Random" in function "__init__"
    "SystemRandom" is incompatible with protocol "_Random"
      "shuffle" is an incompatible type
        Type "(x: MutableSequence[Any]) -> None" cannot be assigned to type "(x: MutableSequence[Any], random: (() -> float) | None = ...) -> None"
          Function accepts too many positional parameters; expected 1 but received 2 (reportGeneralTypeIssues)
1 error, 0 warnings, 0 informations
```

## What has been done

I removed the extra parameter and now pyright is happy. There is no need to add version-specific code: the new version works OK with Python < 3.11.

Ref: https://github.com/python/cpython/pull/25874