### PR TITLE
Expose limiting for * and + in Xeger.xeger()

### DIFF
--- a/rstr/xeger.py
+++ b/rstr/xeger.py
@@ -2,7 +2,7 @@ import random
 import string
 from itertools import chain
 import typing
-from typing import Any, Callable, Dict, Mapping, Pattern, Sequence, Union, Optional
+from typing import Any, Callable, Dict, Mapping, Pattern, Sequence, Union
 
 from rstr.rstr_base import RstrBase
 


### PR DESCRIPTION
Hello!

Thank you for this library, it has been very helpful for me in my project. However, I found that the `Xeger.xeger()` method lacks control over how many characters are generated from a regexp by `*` and `+` metacharacters.

This pull request adds the second argument `star_plus_limit` to this method with the default value of 100. It also removes the constant `STAR_PLUS_LIMIT` as it is no longer needed.