### PR TITLE
Special-case MAXREPEAT

### DIFF
--- a/rstr/__init__.py
+++ b/rstr/__init__.py
@@ -1,5 +1,5 @@
-from rstr.xeger import Xeger
 from rstr.rstr_base import SameCharacterError as SameCharacterError
+from rstr.xeger import Xeger
 
 Rstr = Xeger
 _default_instance = Rstr()

--- a/rstr/rstr_base.py
+++ b/rstr/rstr_base.py
@@ -29,10 +29,9 @@
 
 import itertools
 import string
-from functools import partial
 import typing
+from functools import partial
 from typing import Iterable, List, Mapping, Optional, Sequence, TypeVar
-
 
 _T = TypeVar('_T')
 

--- a/rstr/xeger.py
+++ b/rstr/xeger.py
@@ -2,7 +2,7 @@ import random
 import string
 import typing
 from itertools import chain
-from re._constants import MAXREPEAT
+
 from typing import Any, Callable, Dict, Mapping, Pattern, Sequence, Union
 
 from rstr.rstr_base import RstrBase
@@ -12,8 +12,10 @@ if typing.TYPE_CHECKING:
 
 try:
     import re._parser as sre_parse  # type: ignore[import-not-found]
+    from re._constants import MAXREPEAT  # type: ignore[import-not-found]
 except ImportError:  # Python < 3.11
     import sre_parse
+    from sre_constants import MAXREPEAT
 
 
 class Xeger(RstrBase):

--- a/rstr/xeger.py
+++ b/rstr/xeger.py
@@ -1,8 +1,8 @@
-import warnings
 import random
 import string
-from itertools import chain
 import typing
+from itertools import chain
+from re._constants import MAXREPEAT
 from typing import Any, Callable, Dict, Mapping, Pattern, Sequence, Union
 
 from rstr.rstr_base import RstrBase
@@ -104,9 +104,8 @@ class Xeger(RstrBase):
 
     def _handle_repeat(self, start_range: int, end_range: int, value: str) -> str:
         result = []
-        warnings.warn(f'end_range > {self.star_plus_limit}.')
-        end_range = min((end_range, self.star_plus_limit))
-        start_range = min(start_range, end_range)
+        if end_range is MAXREPEAT:
+            end_range = self.star_plus_limit
 
         times = self._random.randint(start_range, end_range)
         for i in range(times):

--- a/tests/test_package_level_access.py
+++ b/tests/test_package_level_access.py
@@ -1,5 +1,5 @@
-import unittest
 import re
+import unittest
 
 import rstr
 

--- a/tests/test_rstr.py
+++ b/tests/test_rstr.py
@@ -1,6 +1,6 @@
+import random
 import re
 import unittest
-import random
 
 from rstr import Rstr, SameCharacterError
 

--- a/tests/test_xeger.py
+++ b/tests/test_xeger.py
@@ -97,12 +97,24 @@ class TestXeger(unittest.TestCase):
         pattern = r'a*?'
         assert re.match(pattern, self.rs.xeger(pattern))
 
-    def test_handle_repeat_exceeds_limit(self) -> None:
-        pattern = r'\d{101}'
-        ans = r'\d{100}'
-        assert re.match(ans, self.rs.xeger(pattern))
+    def test_exact_repeat_exceeds_star_plus_limit(self) -> None:
+        pattern = r'\d{105}'
+        assert re.match(pattern, self.rs.xeger(pattern))
 
-    def test_handle_repeat_exceeds_limit_with_range(self) -> None:
-        pattern = r'\d{101,103}'
-        ans = r'\d{100}'
-        assert re.match(ans, self.rs.xeger(pattern))
+    def test_range_repeat_exceeds_star_plus_limit(self) -> None:
+        pattern = r'\d{102,105}'
+        assert re.match(pattern, self.rs.xeger(pattern))
+
+    def test_star_repeat_respects_limit(self) -> None:
+        pattern = r'a*'
+        for _ in range(100):
+            result = self.rs.xeger(pattern)
+            assert len(result) <= 100
+            assert re.match(pattern, result)
+
+    def test_plus_repeat_respects_limit(self) -> None:
+        pattern = r'b+'
+        for _ in range(100):
+            result = self.rs.xeger(pattern)
+            assert len(result) <= 100
+            assert re.match(pattern, result)


### PR DESCRIPTION
I think I changed my mind on #38  - I think it _should_ be possible to explicitly ask for repeats longer than the global `star_plus_limit`. That limit should do what it says, and only apply to `*` and `+` repeats.

This adds logic to special case `MAXREPEAT`, while allowing other repeat values.